### PR TITLE
Fixed a problem with the merge. In the refactor var dto = new RDO(); …

### DIFF
--- a/Gravity/Gravity.Test.Integration/RSAPI_IntegrationTest.cs
+++ b/Gravity/Gravity.Test.Integration/RSAPI_IntegrationTest.cs
@@ -334,7 +334,7 @@ namespace Gravity.Test.Integration
 
 				object expectedData = sampleData;
 
-				var dto = new RDO() { Guids = new List<Guid> { testObjectTypeGuid } };
+				var dto = new RDO() { ArtifactTypeGuids = new List<Guid> { testObjectTypeGuid } };
 				int newArtifactId = -1;
 				dto.Fields.Add(new FieldValue(nameFieldGuid, testObject.Name));
 


### PR DESCRIPTION
…dto.ArtifactTypeGuids.Add(testObjectTypeGuid); was changed to var dto = new RDO() { Guids = new List<Guid> { testObjectTypeGuid } }; and should have been var dto = new RDO() { ArtifactTypeGuids = new List<Guid> { testObjectTypeGuid } };