### PR TITLE
Rsapi Delete refactoring and unit tests

### DIFF
--- a/Gravity/Gravity.Test.Unit/RsapiDaoDeleteTests.cs
+++ b/Gravity/Gravity.Test.Unit/RsapiDaoDeleteTests.cs
@@ -1,4 +1,10 @@
-﻿using NUnit.Framework;
+﻿using Gravity.Base;
+using Gravity.DAL.RSAPI;
+using Gravity.Test.TestClasses;
+using kCura.Relativity.Client;
+using kCura.Relativity.Client.DTOs;
+using Moq;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,18 +13,92 @@ using System.Threading.Tasks;
 
 namespace Gravity.Test.Unit
 {
-	[Ignore("TODO: Implement")]
-    public class RsapiDaoDeleteTests
-    {
-		[Test]
-		public void DeleteRelativityObjectRecusively()
-		{
-			//DeleteRelativityObjectRecusively<T>(T theObjectToDelete)
+	public class RsapiDaoDeleteTests
+	{
+		//NUT: not unit testable
 
-			//write a class with nested child objects
-			// DeleteRDO should be called on the root only
-			// Each other level should have DeleteRDOs called on the whole child collection (recursively)
-			throw new NotImplementedException();
+		const int rootId = 1;
+		const int level2Id_1 = 10;
+		const int level2Id_2 = 20;
+
+		Mock<IRsapiProvider> mockProvider;
+
+		[SetUp]
+		public void Init()
+		{
+			mockProvider = new Mock<IRsapiProvider>(MockBehavior.Strict);
 		}
+
+		[SetUp]
+		public void End()
+		{
+			mockProvider.VerifyAll();
+		}
+
+		[Test]
+		public void Delete_NoRecursion_NoChildObjects()
+		{
+			SetupQuery<GravityLevel2Child>(rootId, new int[0]); // no child objects
+			SetupDelete(new[] { rootId }); //delete will occur
+			ExecuteDelete(ObjectFieldsDepthLevel.OnlyParentObject);
+
+			//can have linked single object; will get unlinked - NUT
+			//can have linked multiple object; will get unlined - NUT
+			//can have file field - NUT
+		}
+
+		[Test]
+		public void Delete_NoRecursion_ChildObjects()
+		{
+			SetupQuery<GravityLevel2Child>(rootId, new[] { level2Id_1, level2Id_2 }); //child objects
+			//delete will not occur, throws instead
+			Assert.Throws<ArgumentOutOfRangeException>(() => ExecuteDelete(ObjectFieldsDepthLevel.OnlyParentObject));
+			//fails if has child objects
+		}
+
+		[Test]
+		public void Delete_LevelOneRecursion_ChildObjects()
+		{
+			SetupQuery<GravityLevel2Child>(rootId, new[] { level2Id_1, level2Id_2 });
+			//delete will occur on both levels
+			SetupDelete(new[] { level2Id_1, level2Id_2 });
+			SetupDelete(new[] { rootId });
+			ExecuteDelete(ObjectFieldsDepthLevel.FirstLevelOnly);
+			//succeeds if has child objects; deletes child objects
+		}
+
+		[Test, Ignore("No children of child objects defined")]
+		public void Delete_LevelOneRecustion_LevelTwoObjects()
+		{
+			//fails if has nested child objects
+			//in such case does not delete other child objects either
+		}
+
+		[Test, Ignore("No children of child objects defined")]
+		public void Delete_Recursive_LevelTwoObjects()
+		{
+			//deletes deeply nested child objects
+		}
+
+		private void SetupDelete(int[] artifactIds)
+		{
+			mockProvider.Setup(x => x.Delete(It.Is<List<int>>(
+				y => new HashSet<int>(y).SetEquals(artifactIds))))
+			.Returns(new WriteResultSet<RDO> { Success = true });
+		}
+
+		private void SetupQuery<T>(int parentArtifactId, int[] resultArtifactIds) where T: BaseDto
+		{
+			mockProvider.Setup(x =>
+				x.Query(It.Is<Query<RDO>>(
+					y => y.ArtifactTypeGuid == BaseDto.GetObjectTypeGuid<T>()
+						&& ((WholeNumberCondition)y.Condition).Value.Single() == parentArtifactId)))
+				.Returns(new[] { new QueryResultSet<RDO> {
+					Success = true,
+					Results = resultArtifactIds.Select(y => new Result<RDO> { Success = true, Artifact = new RDO(y) }).ToList() } });
+		}
+
+		private void ExecuteDelete(ObjectFieldsDepthLevel depthLevel)
+			=> new RsapiDao(mockProvider.Object).Delete<GravityLevelOne>(rootId, depthLevel);
 	}
 }

--- a/Gravity/Gravity.Test.Unit/RsapiDaoDeleteTests.cs
+++ b/Gravity/Gravity.Test.Unit/RsapiDaoDeleteTests.cs
@@ -1,5 +1,6 @@
 ﻿using Gravity.Base;
 using Gravity.DAL.RSAPI;
+using Gravity.Test.Helpers;
 using Gravity.Test.TestClasses;
 using kCura.Relativity.Client;
 using kCura.Relativity.Client.DTOs;
@@ -93,9 +94,7 @@ namespace Gravity.Test.Unit
 				x.Query(It.Is<Query<RDO>>(
 					y => y.ArtifactTypeGuid == BaseDto.GetObjectTypeGuid<T>()
 						&& ((WholeNumberCondition)y.Condition).Value.Single() == parentArtifactId)))
-				.Returns(new[] { new QueryResultSet<RDO> {
-					Success = true,
-					Results = resultArtifactIds.Select(y => new Result<RDO> { Success = true, Artifact = new RDO(y) }).ToList() } });
+				.Returns(new[] { resultArtifactIds.Select(y => new RDO(y)).ToSuccessResultSet<QueryResultSet<RDO>>() });
 		}
 
 		private void ExecuteDelete(ObjectFieldsDepthLevel depthLevel)

--- a/Gravity/Gravity/DAL/IGravityDao.cs
+++ b/Gravity/Gravity/DAL/IGravityDao.cs
@@ -6,8 +6,7 @@ namespace Gravity.DAL
 {
 	public interface IGravityDao
 	{
-		void Delete<T>(int artifactID) where T : BaseDto, new();
-		void Delete<T>(T obj) where T : BaseDto;
+		void Delete<T>(int artifactID, ObjectFieldsDepthLevel depthLevel) where T : BaseDto, new();
 		List<T> Get<T>(int[] artifactIDs, ObjectFieldsDepthLevel depthLevel) where T : BaseDto, new();
 		T Get<T>(int artifactID, ObjectFieldsDepthLevel depthLevel) where T : BaseDto, new();
 		int Insert<T>(T obj) where T : BaseDto;

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.Delete.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.Delete.cs
@@ -4,74 +4,75 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Gravity.Base;
-using Gravity.Exceptions;
 using Gravity.Extensions;
 
 namespace Gravity.DAL.RSAPI
 {
 	public partial class RsapiDao
 	{
-		#region RDO DELETE Protected stuff
-		protected void DeleteRDO(int artifactId)
+		public void Delete<T>(int objectToDeleteId, ObjectFieldsDepthLevel depthLevel)
+			where T : BaseDto, new()
 		{
-			rsapiProvider.DeleteSingle(artifactId);
-		}
+			var scanRecursionLevel =
+				depthLevel == ObjectFieldsDepthLevel.OnlyParentObject
+					? ObjectFieldsDepthLevel.FirstLevelOnly //won't need to look past this to throw error
+					: ObjectFieldsDepthLevel.FullyRecursive;
+			T theObjectToDelete = Get<T>(objectToDeleteId, scanRecursionLevel);
 
-		protected void DeleteRDO(Guid artifactGuid)
-		{
-			rsapiProvider.DeleteSingle(artifactGuid);
-		}
+			var maxRecursionLevel =
+				depthLevel == ObjectFieldsDepthLevel.OnlyParentObject ? 0
+				: depthLevel == ObjectFieldsDepthLevel.FirstLevelOnly ? 1
+				: int.MaxValue;
 
-		protected void DeleteRDOs(List<int> artifactIds)
-		{
-			rsapiProvider.Delete(artifactIds)
-				.GetResultData(); //ensure no exceptions
-		}
-		#endregion
+			//artifactID / recursion level tuple for items to delete
+			var artifactsToDeleteList = new List<Tuple<int, int>>();
 
-		internal void DeleteChildObjects<T>(IList<T> parentObjectList, List<int> artifactIds) where T : BaseDto
-		{
-			var childObjectsInfo = BaseDto.GetRelativityObjectChildrenListProperties<T>();
+			//populate artifacts to delete
+			PopulateArtifactsToDeleteList(artifactsToDeleteList, maxRecursionLevel, new[] { theObjectToDelete }, 0);
 
-			foreach (var parentObject in parentObjectList)
+			//order by items to delete by how deep in hierarchy they are
+			//so don't run into "can't delete" issues
+			var deleteSets = artifactsToDeleteList
+				.ToLookup(x => x.Item2, x => x.Item1)
+				.OrderByDescending(x => x.Key);
+
+			foreach (var deleteSet in deleteSets)
 			{
-				DeleteChildObjectsInner(parentObject, childObjectsInfo);
+				rsapiProvider.Delete(deleteSet.ToList()).GetResultData();
 			}
 
-			DeleteRDOs(artifactIds);
 		}
 
-		public void Delete<T>(T theObjectToDelete) where T : BaseDto
+		internal void PopulateArtifactsToDeleteList<T>(
+			List<Tuple<int, int>> artifactsToDeleteList,
+			int maxRecursionLevel,
+			IList<T> artifacts,
+			int currentRecursionLevel) where T : BaseDto
 		{
-			var childObjectsInfo = BaseDto.GetRelativityObjectChildrenListProperties<T>();
-			DeleteChildObjectsInner(theObjectToDelete, childObjectsInfo);
-			DeleteRDO(theObjectToDelete.ArtifactId);
-		}
+			if (!artifacts.Any())
+				return;
 
-		public void Delete<T>(int objectToDeleteId) where T : BaseDto, new()
-		{
-			T theObjectToDelete = Get<T>(objectToDeleteId, Base.ObjectFieldsDepthLevel.FullyRecursive);
-			Delete(theObjectToDelete);
-		}
+			if (currentRecursionLevel > maxRecursionLevel)
+				throw new ArgumentOutOfRangeException(nameof(maxRecursionLevel), "Exceeded maximum recursion level.");
 
-		private void DeleteChildObjectsInner<T>(T theObjectToDelete, IEnumerable<PropertyInfo> childProperties) 
-			where T : BaseDto
-		{
+			artifactsToDeleteList.AddRange(artifacts.Select(a => Tuple.Create(a.ArtifactId, currentRecursionLevel)));
+
+
+			var childProperties = BaseDto.GetRelativityObjectChildrenListProperties<T>();
+
 			foreach (var propertyInfo in childProperties)
 			{
-
-				var thisChildTypeObj = propertyInfo.GetValue(theObjectToDelete, null) as IList;
-
-				List<int> thisArtifactIDs = thisChildTypeObj.Cast<object>()
-					.Select(item => ((BaseDto)item).ArtifactId)
-					.ToList();
-
-				if (thisArtifactIDs.Count != 0)
+				var childType = propertyInfo.PropertyType.GetEnumerableInnerType();
+				foreach (var parentObject in artifacts)
 				{
-					Type childType = propertyInfo.PropertyType.GetEnumerableInnerType();
-					this.InvokeGenericMethod(childType, nameof(DeleteChildObjects), thisChildTypeObj, thisArtifactIDs);
+					var thisChildTypeObjs = propertyInfo.GetValue(parentObject, null) as IList;
+
+					//recurse with child objects and next recursion level
+					this.InvokeGenericMethod(childType, nameof(PopulateArtifactsToDeleteList),
+						artifactsToDeleteList, maxRecursionLevel, thisChildTypeObjs, currentRecursionLevel + 1);
 				}
 			}
+
 		}
 	}
 }

--- a/Gravity/Gravity/DAL/RSAPI/RsapiDao.Delete.cs
+++ b/Gravity/Gravity/DAL/RSAPI/RsapiDao.Delete.cs
@@ -13,12 +13,6 @@ namespace Gravity.DAL.RSAPI
 		public void Delete<T>(int objectToDeleteId, ObjectFieldsDepthLevel depthLevel)
 			where T : BaseDto, new()
 		{
-			var scanRecursionLevel =
-				depthLevel == ObjectFieldsDepthLevel.OnlyParentObject
-					? ObjectFieldsDepthLevel.FirstLevelOnly //won't need to look past this to throw error
-					: ObjectFieldsDepthLevel.FullyRecursive;
-			T theObjectToDelete = Get<T>(objectToDeleteId, scanRecursionLevel);
-
 			var maxRecursionLevel =
 				depthLevel == ObjectFieldsDepthLevel.OnlyParentObject ? 0
 				: depthLevel == ObjectFieldsDepthLevel.FirstLevelOnly ? 1
@@ -28,7 +22,7 @@ namespace Gravity.DAL.RSAPI
 			var artifactsToDeleteList = new List<Tuple<int, int>>();
 
 			//populate artifacts to delete
-			PopulateArtifactsToDeleteList(artifactsToDeleteList, maxRecursionLevel, new[] { theObjectToDelete }, 0);
+			PopulateArtifactsToDeleteList<T>(artifactsToDeleteList, maxRecursionLevel, new[] { objectToDeleteId }, 0);
 
 			//order by items to delete by how deep in hierarchy they are
 			//so don't run into "can't delete" issues
@@ -46,30 +40,30 @@ namespace Gravity.DAL.RSAPI
 		internal void PopulateArtifactsToDeleteList<T>(
 			List<Tuple<int, int>> artifactsToDeleteList,
 			int maxRecursionLevel,
-			IList<T> artifacts,
+			IList<int> artifactIds,
 			int currentRecursionLevel) where T : BaseDto
 		{
-			if (!artifacts.Any())
+			if (!artifactIds.Any())
 				return;
 
 			if (currentRecursionLevel > maxRecursionLevel)
-				throw new ArgumentOutOfRangeException(nameof(maxRecursionLevel), "Exceeded maximum recursion level.");
+				throw new ArgumentOutOfRangeException(nameof(currentRecursionLevel), "Exceeded maximum recursion level.");
 
-			artifactsToDeleteList.AddRange(artifacts.Select(a => Tuple.Create(a.ArtifactId, currentRecursionLevel)));
-
+			artifactsToDeleteList.AddRange(artifactIds.Select(a => Tuple.Create(a, currentRecursionLevel)));
 
 			var childProperties = BaseDto.GetRelativityObjectChildrenListProperties<T>();
 
 			foreach (var propertyInfo in childProperties)
 			{
 				var childType = propertyInfo.PropertyType.GetEnumerableInnerType();
-				foreach (var parentObject in artifacts)
+				foreach (var artifactId in artifactIds)
 				{
-					var thisChildTypeObjs = propertyInfo.GetValue(parentObject, null) as IList;
+					//TODO: amend so can pass in all artifact IDs instead of looping over artifacts
+					var thisChildTypeIds = (List<int>)this.InvokeGenericMethod(childType, nameof(GetAllChildIds), artifactId);
 
 					//recurse with child objects and next recursion level
 					this.InvokeGenericMethod(childType, nameof(PopulateArtifactsToDeleteList),
-						artifactsToDeleteList, maxRecursionLevel, thisChildTypeObjs, currentRecursionLevel + 1);
+						artifactsToDeleteList, maxRecursionLevel, thisChildTypeIds, currentRecursionLevel + 1);
 				}
 			}
 


### PR DESCRIPTION
This PR makes the Delete method take and respect the recursion flag per https://github.com/relativitydev/Gravity/issues/106#issuecomment-409344786 . It also adds unit tests to that effect.

I have not tested this in Relativity itself, but we don't have integration tests for delete operations anyways yet, and I don't have time to write both those _and_ the unit tests.