### PR TITLE
Remove dud VerifyAll methods

### DIFF
--- a/Gravity/Gravity.Test.Unit/RsapiDaoDeleteTests.cs
+++ b/Gravity/Gravity.Test.Unit/RsapiDaoDeleteTests.cs
@@ -33,12 +33,6 @@ namespace Gravity.Test.Unit
 			mockProvider = new Mock<IRsapiProvider>(MockBehavior.Strict);
 		}
 
-		[SetUp]
-		public void End()
-		{
-			mockProvider.VerifyAll();
-		}
-
 		[Test]
 		public void Delete_NoRecursion_NoChildObjects()
 		{

--- a/Gravity/Gravity.Test.Unit/RsapiDaoInsertTests.cs
+++ b/Gravity/Gravity.Test.Unit/RsapiDaoInsertTests.cs
@@ -33,13 +33,6 @@ namespace Gravity.Test.Unit
 			mockProvider = new Mock<IRsapiProvider>(MockBehavior.Strict);
 		}
 
-		[SetUp]
-		public void End()
-		{
-			//ensure any defined methods called
-			mockProvider.VerifyAll();
-		}
-
 		[Test]
 		public void Insert_SimpleFields()
 		{

--- a/Gravity/Gravity.Test.Unit/RsapiDaoUpdateTests.cs
+++ b/Gravity/Gravity.Test.Unit/RsapiDaoUpdateTests.cs
@@ -38,13 +38,6 @@ namespace Gravity.Test.Unit
 			mockProvider = new Mock<IRsapiProvider>(MockBehavior.Strict);
 		}
 
-		[SetUp]
-		public void End()
-		{
-			//ensure any defined methods called
-			mockProvider.VerifyAll();
-		}
-
 		[Test]
 		public void Update_SimpleFields()
 		{


### PR DESCRIPTION
Until we can fix #142, we might as well move the misleading methods out of the way.